### PR TITLE
TouchScreen.h does not work with Arduino UNO WiFi rev2

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -8,12 +8,12 @@
 #include <stdint.h>
 
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||              \
-    defined(TEENSYDUINO) || defined(__AVR_ATmega2560__)
+    defined(TEENSYDUINO) || defined(__AVR_ATmega2560__) || defined(__AVR_ATmega4809__)
 typedef volatile uint8_t RwReg;
 #elif defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
 #elif defined(NRF52_SERIES) || defined(ESP32) || defined(ESP8266) ||           \
-    defined(ARDUINO_ARCH_STM32)
+   defined(ARDUINO_ARCH_STM32)
 typedef volatile uint32_t RwReg;
 #else
 typedef volatile uint32_t RwReg;


### PR DESCRIPTION
This is a fairly simple issue that I think Could be easily fixed.
the defined for Rev2 is "AVR_ATmega4809" this in not included in current release.
I had purchased " 3.5" TFT 320X480 + TOUCHSCREEN BREAKOUT BOARD W/MICROSD SOCKET" and was following the setup instructions. Understanding that my rev2 board does not match the getting started instructions.

I went back a forth a bit, where this release works perfect with Arduino UNO, but not with rev2
Where the define is "AVR_ATmega328P"
Just switching boards give compile errors.

I spent a lot of time on this, so adding this board to TouchScreen.h could save someone else some time and frustration. Time is better spent playing with a really cool product.

Released Code
#if defined(AVR_ATmega328P) || defined(AVR_ATmega32U4) || 
defined(TEENSYDUINO) || defined(AVR_ATmega2560)
typedef volatile uint8_t RwReg;
#elif defined(ARDUINO_STM32_FEATHER)
typedef volatile uint32 RwReg;
#elif defined(NRF52_SERIES) || defined(ESP32) || defined(ESP8266) || 
defined(ARDUINO_ARCH_STM32)
typedef volatile uint32_t RwReg;
#else
typedef volatile uint32_t RwReg;
#endif

Recommended Change
#if defined(AVR_ATmega328P) || defined(AVR_ATmega32U4) || 
defined(TEENSYDUINO) || defined(AVR_ATmega2560) || defined(AVR_ATmega4809)
typedef volatile uint8_t RwReg;
#elif defined(ARDUINO_STM32_FEATHER)
typedef volatile uint32 RwReg;
#elif defined(NRF52_SERIES) || defined(ESP32) || defined(ESP8266) || 
defined(ARDUINO_ARCH_STM32)
typedef volatile uint32_t RwReg;
#else
typedef volatile uint32_t RwReg;
#endif

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
